### PR TITLE
Add link to supply module

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you are working on a module that you would like to be used by the community, 
 - [Cosmos SDK - Params](https://github.com/cosmos/cosmos-sdk/tree/master/docs/spec/params)
 - [Cosmos SDK - Slashing](https://github.com/cosmos/cosmos-sdk/tree/master/docs/spec/slashing)
 - [Cosmos SDK - Staking](https://github.com/cosmos/cosmos-sdk/tree/master/docs/spec/staking)
+- [Cosmos SDK - Supply](https://github.com/cosmos/cosmos-sdk/tree/master/docs/spec/supply)
 - [Kava - CDP System](https://github.com/Kava-Labs/kava-devnet/tree/master/blockchain/x)
 - [Kava - Payment Channels](https://github.com/Kava-Labs/cosmos-paychan)
 


### PR DESCRIPTION
A new module is being introduced in the v0.36 release. I've added a link to its specification.