### PR TITLE
Add client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Please read the [contributing guide](./contributing.md). Thank you to all our [c
 ## Client Libraries
 ### Javascript
 - [cosmos/sig](https://github.com/cosmos/sig) - Cosmos Signing Library 
+- [cosmostation/cosmosjs](https://github.com/cosmostation/cosmosjs) - Cosmostation Signing & API Library
+- [everett-protocol/cosmosjs](https://github.com/everett-protocol/cosmosjs) - Everett Signing & API Library
 - [luniehq/cosmos-api](https://github.com/luniehq/cosmos-api) - Lunie API Library 
 - [luniehq/cosmos-keys](https://github.com/luniehq/cosmos-keys) - Lunie Signing Library 
-- [everett-protocol/cosmosjs](https://github.com/everett-protocol/cosmosjs) - Everett Signing & API Library
 ### Rust
 - [iqlusion/stdtx](https://github.com/iqlusioninc/crates/tree/develop/stdtx) - Iqlusion StdTx
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Please read the [contributing guide](./contributing.md). Thank you to all our [c
 - [Trust Wallet](https://trustwallet.com/)
 - [Wetez](https://www.wetez.io/homepage)
 
+## Client Libraries
+### Javascript
+- [cosmos/sig](https://github.com/cosmos/sig) - Cosmos Signing Library 
+- [luniehq/cosmos-api](https://github.com/luniehq/cosmos-api) - Lunie API Library 
+- [luniehq/cosmos-keys](https://github.com/luniehq/cosmos-keys) - Lunie Signing Library 
+- [everett-protocol/cosmosjs](https://github.com/everett-protocol/cosmosjs) - Everett Signing & API Library
+### Rust
+- [iqlusion/stdtx](https://github.com/iqlusioninc/crates/tree/develop/stdtx) - Iqlusion StdTx
+
 ## Block Explorers
 
 - [Big Dipper](https://bigdipper.forbole.com/)


### PR DESCRIPTION
Added js libs. I think there must be more missing. Might be good to write which version of the SDK they support or whether they are aimed at supporting a specific chain or generic chain. 

Question: Should [binance/javascript-sdk](https://github.com/binance-chain/javascript-sdk) be included? 